### PR TITLE
Enable variable "zabbix_agent_become_on_localhost"

### DIFF
--- a/roles/zabbix_agent/tasks/api.yml
+++ b/roles/zabbix_agent/tasks/api.yml
@@ -8,6 +8,7 @@
   register: zabbix_api_hostgroup_created
   until: zabbix_api_hostgroup_created is succeeded
   delegate_to: "{{ zabbix_api_server_host }}"
+  become: "{{zabbix_agent_become_on_localhost}}"
   tags:
     - api
 
@@ -41,6 +42,7 @@
   register: zabbix_api_host_created
   until: zabbix_api_host_created is succeeded
   delegate_to: "{{ zabbix_api_server_host }}"
+  become: "{{zabbix_agent_become_on_localhost}}"
   changed_when: false
   tags:
     - api
@@ -75,6 +77,7 @@
   register: zabbix_api_host_created
   until: zabbix_api_host_created is succeeded
   delegate_to: "{{ zabbix_api_server_host }}"
+  become: "{{zabbix_agent_become_on_localhost}}"
   changed_when: false
   tags:
     - api
@@ -92,5 +95,6 @@
   register: zabbix_api_hostmarcro_created
   until: zabbix_api_hostmarcro_created is succeeded
   delegate_to: "{{ zabbix_api_server_host }}"
+  become: "{{zabbix_agent_become_on_localhost}}"
   tags:
     - api


### PR DESCRIPTION
If variable "zabbix_agent_become_on_localhost" is set to false, on localhost shouldn't use sudo.